### PR TITLE
Allow build with CGO_ENABLED=0 by disable TUN Mode

### DIFF
--- a/pkg/tun/server.go
+++ b/pkg/tun/server.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package tun
 
 import (

--- a/pkg/tun/server_fake.go
+++ b/pkg/tun/server_fake.go
@@ -1,0 +1,44 @@
+// +build !cgo
+
+package tun
+
+import (
+	"errors"
+	"github.com/tobyxdd/hysteria/pkg/acl"
+	"github.com/tobyxdd/hysteria/pkg/core"
+	"github.com/tobyxdd/hysteria/pkg/transport"
+	"io"
+	"net"
+	"time"
+)
+
+type Server struct {
+	HyClient  *core.Client
+	Timeout   time.Duration
+	TunDev    io.ReadWriteCloser
+	Transport transport.Transport
+	ACLEngine *acl.Engine
+
+	RequestFunc func(addr net.Addr, reqAddr string, action acl.Action, arg string)
+	ErrorFunc   func(addr net.Addr, reqAddr string, err error)
+}
+
+const (
+	MTU = 1500
+)
+
+func NewServerWithTunDev(hyClient *core.Client, transport transport.Transport,
+	timeout time.Duration,
+	tunDev io.ReadWriteCloser) (*Server, error) {
+	return nil, errors.New("TUN mode is not available when build with CGO_ENABLED=0")
+}
+
+func NewServer(hyClient *core.Client, transport transport.Transport,
+	timeout time.Duration,
+	name, address, gateway, mask string, dnsServers []string, persist bool) (*Server, error) {
+	return nil, errors.New("TUN mode is not available when build with CGO_ENABLED=0")
+}
+
+func (s *Server) ListenAndServe() error {
+	panic("not implemented!")
+}

--- a/pkg/tun/tcp.go
+++ b/pkg/tun/tcp.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package tun
 
 import (

--- a/pkg/tun/udp.go
+++ b/pkg/tun/udp.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package tun
 
 import (


### PR DESCRIPTION
So we can build a statically linked executable and make it easier to run hysteria on the OpenWRT.

ref: https://t.me/hysteria_github/1706
ref: https://t.me/c/1455796760/28966