### PR TITLE
chore(docker): set up nsswitch.conf for Go's "netgo" implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ ARG GOPROXY=""
 
 ENV GOPROXY ${GOPROXY}
 
-COPY . /go/src/github.com/tobyxdd/hysteria
+COPY . /go/src/github.com/hynetwork/hysteria
 
-WORKDIR /go/src/github.com/tobyxdd/hysteria/cmd
+WORKDIR /go/src/github.com/hynetwork/hysteria/cmd
 
 RUN set -ex \
     && apk add git build-base \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ FROM alpine AS dist
 
 LABEL maintainer="mritd <mritd@linux.com>"
 
+# set up nsswitch.conf for Go's "netgo" implementation
+# - https://github.com/golang/go/blob/go1.9.1/src/net/conf.go#L194-L275
+# - docker run --rm debian:stretch grep '^hosts:' /etc/nsswitch.conf
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
 # bash is used for debugging, tzdata is used to add timezone information.
 # Install ca-certificates to ensure no CA certificate errors.
 #


### PR DESCRIPTION
set up nsswitch.conf for Go's "netgo" implementation

Signed-off-by: mritd <mritd@linux.com>