### PR TITLE
Remove targets= ~ to allow for building to more archs

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -33,7 +33,6 @@ jobs:
           go_version: 1.17
           dest: dist
           prefix: hysteria
-          targets: linux/amd64,linux/386,linux/arm-5,linux/arm-7,linux/arm64,linux/s390x,linux/mipsle,darwin-10.12/amd64,darwin-10.12/arm64,windows-6.0/amd64,windows-6.0/386
           ldflags: -w -s -X main.appCommit=${{ github.sha }} -X main.appDate=${{ env.TIME }}
           pkg: cmd
 

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -33,7 +33,7 @@ jobs:
           go_version: 1.17
           dest: dist
           prefix: hysteria
-          targets: linux/amd64,linux/386,linux/arm-5,linux/arm-7,linux/arm64,linux/mipsle,darwin-10.12/amd64,darwin-10.12/arm64,windows-6.0/amd64,windows-6.0/386
+          targets: linux/amd64,linux/386,linux/arm-5,linux/arm-7,linux/arm64,linux/s390x,linux/mipsle,darwin-10.12/amd64,darwin-10.12/arm64,windows-6.0/amd64,windows-6.0/386
           ldflags: -w -s -X main.appCommit=${{ github.sha }} -X main.appDate=${{ env.TIME }}
           pkg: cmd
 

--- a/go.mod
+++ b/go.mod
@@ -73,4 +73,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
+
 replace github.com/lucas-clemente/quic-go => github.com/tobyxdd/quic-go v0.24.0-mod


### PR DESCRIPTION
As with title, removing this argument allows the building of many more archs, especially for linux. (See last commit, the other two does not have any meaningful changes)