### PR TITLE
Allow users disable the auto reconnect behavior and related timeout

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,7 +23,7 @@ const (
 
 	DefaultMMDBFilename = "GeoLite2-Country.mmdb"
 
-	KeepAlivePeriod = 10 * time.Second
+	DefaultKeepAlivePeriod = 10 * time.Second
 )
 
 var rateStringRegexp = regexp.MustCompile(`^(\d+)\s*([KMGT]?)([Bb])ps$`)
@@ -147,11 +147,11 @@ type clientConfig struct {
 	Retry         int    `json:"retry"`
 	RetryInterval int    `json:"retry_interval"`
 	// Optional below
-	QUICSettings struct {
+	Connectivity struct {
 		DisableAutoReconnect bool `json:"disable_auto_reconnect"`
 		HandshakeIdleTimeout int  `json:"handshake_idle_timeout"`
 		MaxIdleTimeout       int  `json:"max_idle_timeout"`
-	} `json:"quic_settings"`
+	} `json:"connectivity"`
 	SOCKS5 struct {
 		Listen     string `json:"listen"`
 		Timeout    int    `json:"timeout"`
@@ -235,6 +235,12 @@ func (c *clientConfig) Check() error {
 		len(c.TCPTProxy.Listen) == 0 && len(c.UDPTProxy.Listen) == 0 &&
 		len(c.TCPRedirect.Listen) == 0 {
 		return errors.New("please enable at least one mode")
+	}
+	if c.Connectivity.HandshakeIdleTimeout != 0 && c.Connectivity.HandshakeIdleTimeout <= 2 {
+		return errors.New("invalid handshake idle timeout")
+	}
+	if c.Connectivity.MaxIdleTimeout != 0 && c.Connectivity.MaxIdleTimeout <= 4 {
+		return errors.New("invalid max idle timeout")
 	}
 	if c.SOCKS5.Timeout != 0 && c.SOCKS5.Timeout <= 4 {
 		return errors.New("invalid SOCKS5 timeout")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -147,6 +147,11 @@ type clientConfig struct {
 	Retry         int    `json:"retry"`
 	RetryInterval int    `json:"retry_interval"`
 	// Optional below
+	QUICSettings struct {
+		DisableAutoReconnect bool `json:"disable_auto_reconnect"`
+		HandshakeIdleTimeout int  `json:"handshake_idle_timeout"`
+		MaxIdleTimeout       int  `json:"max_idle_timeout"`
+	} `json:"quic_settings"`
 	SOCKS5 struct {
 		Listen     string `json:"listen"`
 		Timeout    int    `json:"timeout"`

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -131,7 +131,7 @@ func (r *Relay) Check() error {
 	if len(r.Remote) == 0 {
 		return errors.New("no relay remote address")
 	}
-	if r.Timeout != 0 && r.Timeout <= 4 {
+	if r.Timeout != 0 && r.Timeout < 4 {
 		return errors.New("invalid relay timeout")
 	}
 	return nil
@@ -236,16 +236,16 @@ func (c *clientConfig) Check() error {
 		len(c.TCPRedirect.Listen) == 0 {
 		return errors.New("please enable at least one mode")
 	}
-	if c.Connectivity.HandshakeIdleTimeout != 0 && c.Connectivity.HandshakeIdleTimeout <= 2 {
+	if c.Connectivity.HandshakeIdleTimeout != 0 && c.Connectivity.HandshakeIdleTimeout < 2 {
 		return errors.New("invalid handshake idle timeout")
 	}
-	if c.Connectivity.MaxIdleTimeout != 0 && c.Connectivity.MaxIdleTimeout <= 4 {
+	if c.Connectivity.MaxIdleTimeout != 0 && c.Connectivity.MaxIdleTimeout < 4 {
 		return errors.New("invalid max idle timeout")
 	}
-	if c.SOCKS5.Timeout != 0 && c.SOCKS5.Timeout <= 4 {
+	if c.SOCKS5.Timeout != 0 && c.SOCKS5.Timeout < 4 {
 		return errors.New("invalid SOCKS5 timeout")
 	}
-	if c.HTTP.Timeout != 0 && c.HTTP.Timeout <= 4 {
+	if c.HTTP.Timeout != 0 && c.HTTP.Timeout < 4 {
 		return errors.New("invalid HTTP timeout")
 	}
 	if c.TUN.Timeout != 0 && c.TUN.Timeout < 4 {
@@ -257,10 +257,10 @@ func (c *clientConfig) Check() error {
 	if len(c.UDPRelay.Listen) > 0 && len(c.UDPRelay.Remote) == 0 {
 		return errors.New("no UDP relay remote address")
 	}
-	if c.TCPRelay.Timeout != 0 && c.TCPRelay.Timeout <= 4 {
+	if c.TCPRelay.Timeout != 0 && c.TCPRelay.Timeout < 4 {
 		return errors.New("invalid TCP relay timeout")
 	}
-	if c.UDPRelay.Timeout != 0 && c.UDPRelay.Timeout <= 4 {
+	if c.UDPRelay.Timeout != 0 && c.UDPRelay.Timeout < 4 {
 		return errors.New("invalid UDP relay timeout")
 	}
 	for _, r := range c.TCPRelays {
@@ -273,13 +273,13 @@ func (c *clientConfig) Check() error {
 			return err
 		}
 	}
-	if c.TCPTProxy.Timeout != 0 && c.TCPTProxy.Timeout <= 4 {
+	if c.TCPTProxy.Timeout != 0 && c.TCPTProxy.Timeout < 4 {
 		return errors.New("invalid TCP TProxy timeout")
 	}
-	if c.UDPTProxy.Timeout != 0 && c.UDPTProxy.Timeout <= 4 {
+	if c.UDPTProxy.Timeout != 0 && c.UDPTProxy.Timeout < 4 {
 		return errors.New("invalid UDP TProxy timeout")
 	}
-	if c.TCPRedirect.Timeout != 0 && c.TCPRedirect.Timeout <= 4 {
+	if c.TCPRedirect.Timeout != 0 && c.TCPRedirect.Timeout < 4 {
 		return errors.New("invalid TCP Redirect timeout")
 	}
 	if len(c.Server) == 0 {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -77,7 +77,7 @@ func server(config *serverConfig) {
 		InitialConnectionReceiveWindow: config.ReceiveWindowClient,
 		MaxConnectionReceiveWindow:     config.ReceiveWindowClient,
 		MaxIncomingStreams:             int64(config.MaxConnClient),
-		KeepAlivePeriod:                KeepAlivePeriod,
+		KeepAlivePeriod:                DefaultKeepAlivePeriod,
 		DisablePathMTUDiscovery:        config.DisableMTUDiscovery,
 		EnableDatagrams:                true,
 	}


### PR DESCRIPTION
According to the discuss #420, some users want hysteria to exit rather than auto re-connect when the QUIC connection is interrupted.

And some related timeout options are also exposed into the config, as I think the default `MaxIdleTimeout` (30s) is too long in this use case.

p.s. I don't think the `"quic_settings"` is a great name (and it really looks like an inbound), feel free to advise if you have a better idea.